### PR TITLE
Make random-access reader constructors public (#16)

### DIFF
--- a/library/src/main/java/com/sandflow/smpte/mxf/ClipReader.java
+++ b/library/src/main/java/com/sandflow/smpte/mxf/ClipReader.java
@@ -58,7 +58,7 @@ public class ClipReader extends InputStream {
    * @throws IOException  If an I/O error occurs.
    * @throws KLVException If a KLV error occurs.
    */
-  ClipReader(RandomAccessFileInfo info, RandomAccessInputSource source) throws IOException, KLVException {
+  public ClipReader(RandomAccessFileInfo info, RandomAccessInputSource source) throws IOException, KLVException {
     this.info = info;
     this.source = source;
 

--- a/library/src/main/java/com/sandflow/smpte/mxf/FrameReader.java
+++ b/library/src/main/java/com/sandflow/smpte/mxf/FrameReader.java
@@ -52,7 +52,7 @@ public class FrameReader extends StreamingReader {
    * @throws KLVException If a KLV error occurs.
    * @throws MXFException If an MXF error occurs.
    */
-  FrameReader(RandomAccessFileInfo info, RandomAccessInputSource source)
+  public FrameReader(RandomAccessFileInfo info, RandomAccessInputSource source)
       throws IOException, KLVException, MXFException {
     super(source, null);
 

--- a/library/src/main/java/com/sandflow/smpte/mxf/GenericStreamReader.java
+++ b/library/src/main/java/com/sandflow/smpte/mxf/GenericStreamReader.java
@@ -58,7 +58,7 @@ public class GenericStreamReader extends InputStream {
    * @throws IOException  If an I/O error occurs.
    * @throws KLVException If a KLV error occurs.
    */
-  GenericStreamReader(RandomAccessFileInfo info, RandomAccessInputSource source) throws IOException, KLVException {
+  public GenericStreamReader(RandomAccessFileInfo info, RandomAccessInputSource source) throws IOException, KLVException {
     Objects.requireNonNull(info);
     Objects.requireNonNull(source);
 

--- a/library/src/main/java/com/sandflow/smpte/mxf/RandomAccessFileInfo.java
+++ b/library/src/main/java/com/sandflow/smpte/mxf/RandomAccessFileInfo.java
@@ -159,7 +159,7 @@ public class RandomAccessFileInfo {
    * @throws KLVException If a KLV parsing error occurs.
    * @throws MXFException If an MXF-specific error occurs.
    */
-  RandomAccessFileInfo(RandomAccessInputSource raip, EventHandler evthandler)
+  public RandomAccessFileInfo(RandomAccessInputSource raip, EventHandler evthandler)
       throws IOException, KLVException, MXFException {
     if (raip == null) {
       throw new IllegalArgumentException("No input source provided");


### PR DESCRIPTION
Fixes #16.
The README documents `RandomAccessFileInfo` as a primary entry point, but its constructor
and those of `ClipReader`, `FrameReader`, and `GenericStreamReader` are all package-private, so the
documented random-access API can't be instantiated outside `com.sandflow.smpte.mxf`. This makes
the four constructors public, mirroring `StreamingFileInfo`.