### PR TITLE
Fix RandomAccessFileInfo index-table parsing: allow IndexDuration == 0 and skip fill items

### DIFF
--- a/library/src/main/java/com/sandflow/smpte/mxf/RandomAccessFileInfo.java
+++ b/library/src/main/java/com/sandflow/smpte/mxf/RandomAccessFileInfo.java
@@ -86,12 +86,13 @@ public class RandomAccessFileInfo {
     private long length;
 
     CBEClipIndex(long cbeSize, long length) {
-      if (length <= 0) {
-        throw new IllegalArgumentException();
+      if (cbeSize <= 0) {
+        throw new IllegalArgumentException("EditUnitByteCount (cbeSize) must be > 0 for CBE indexing");
       }
 
-      if (length <= 0) {
-        throw new IllegalArgumentException();
+      /* IndexDuration of 0 is permitted by ST 377-1 §11.1.9 (unspecified / entire essence container) */
+      if (length < 0) {
+        throw new IllegalArgumentException("IndexDuration (length) must not be negative");
       }
       this.cbeSize = cbeSize;
       this.length = length;
@@ -99,7 +100,8 @@ public class RandomAccessFileInfo {
 
     @Override
     public long getECPosition(long editUnit) {
-      if (editUnit >= this.length) {
+      /* length == 0 means the duration is unspecified (ST 377-1 §11.1.9), so only bound-check when known */
+      if (this.length > 0 && editUnit >= this.length) {
         throw new IllegalArgumentException();
       }
       return this.cbeSize * editUnit;
@@ -295,8 +297,15 @@ public class RandomAccessFileInfo {
 
         /* read Index Segments until the IndexByteCount is exceeded */
         while (mis.getReadCount() < pp.getIndexByteCount()) {
+          Triplet it = mis.readTriplet();
+
+          /* skip fill items that pad the index byte count to the KAG */
+          if (FillItem.getKey().equalsIgnoreVersion(it.getKey())) {
+            continue;
+          }
+
           IndexTableSegment its = IndexTableSegment.fromSet(
-              Set.fromLocalSet(mis.readTriplet(), StaticLocalTags.register()),
+              Set.fromLocalSet(it, StaticLocalTags.register()),
               new MXFInputContext() {
                 @Override
                 public Set getSet(UUID uuid) {


### PR DESCRIPTION
Two independent fixes to `RandomAccessFileInfo` index-table parsing, both needed to open
valid IMF App #2E files that the random-access reader currently rejects.
1. **Allow `IndexDuration == 0` for CBE clip indexes.** Fixes #17.
   `CBEClipIndex` rejected `length <= 0`, but `IndexDuration == 0` is legal (SMPTE ST 377-1
   §11.1.9) for a CBE index that omits the Index Entry Array -- positions are derived from
   `EditUnitByteCount`. Also drops the duplicated guard.
   
2. **Skip KLV fill items in the index-segment loop.** Fixes #18.
   The loop fed every triplet to `IndexTableSegment.fromSet(...)`, so a fill item in the index
   byte range caused `IllegalArgumentException` ("Cannot read from an empty Set"). This mirrors
   `RegMXFDump`, which already skips fill items in the same loop (commit 47fad89).
