### PR TITLE
Return 0 for a valid 0x00 short-form BER length instead of throwing EOF

### DIFF
--- a/common/src/main/java/com/sandflow/smpte/klv/KLVDataInput.java
+++ b/common/src/main/java/com/sandflow/smpte/klv/KLVDataInput.java
@@ -150,7 +150,7 @@ public class KLVDataInput {
 
     int b = read();
 
-    if (b <= 0) {
+    if (b < 0) {
       throw new EOFException();
     }
 


### PR DESCRIPTION
## Summary
`KLVDataInput.readBERLength()` threw `EOFException` when the length field was a single `0x00` byte,
which is a valid BER short-form length of 0. `read()` returns `0` for a `0x00` byte and `-1` at end
of stream, but the guard tested `b <= 0`, conflating the two. The guard is changed to `b < 0` so only
a true end of stream throws; `0x00` now falls through to the short-form branch and returns 0.

Fixes #22