### PR TITLE
Reject the 0x80 non-deterministic length marker instead of decoding it as 0

### DIFF
--- a/common/src/main/java/com/sandflow/smpte/klv/KLVDataInput.java
+++ b/common/src/main/java/com/sandflow/smpte/klv/KLVDataInput.java
@@ -158,6 +158,10 @@ public class KLVDataInput {
       return b;
     }
 
+    if (b == 0x80) {
+      throw new KLVException("First byte of length field equals 0x80 (non-deterministic length)");
+    }
+
     int bersz = (b & 0x0f);
 
     if (bersz > 8) {


### PR DESCRIPTION
## Summary
`KLVDataInput.readBERLength()` decoded a `0x80` first byte as a definite length of 0: it is treated
as long form, and `0x80 & 0x0f` yields 0 subsequent octets, so the method reads nothing and returns
0. Per SMPTE ST 336 §5.3, `0x80` is the reserved "non-deterministic length" marker, not a definite
length, and should be rejected. This adds an explicit check that throws `KLVException` on `0x80` in
the long-form branch.

Fixes #23