### PR TITLE
Allow BER length larger than Integer.MAX_VALUE & Fix fill item validation

### DIFF
--- a/common/src/main/java/com/sandflow/smpte/klv/KLVDataInput.java
+++ b/common/src/main/java/com/sandflow/smpte/klv/KLVDataInput.java
@@ -30,6 +30,7 @@
 
 package com.sandflow.smpte.klv;
 
+import static com.sandflow.smpte.klv.exceptions.KLVException.MAX_BER_SIZE_EXCEEED;
 import static com.sandflow.smpte.klv.exceptions.KLVException.MAX_LENGTH_EXCEEED;
 
 import java.io.EOFException;
@@ -161,7 +162,7 @@ public class KLVDataInput {
     int bersz = (b & 0x0f);
 
     if (bersz > 8) {
-      throw new KLVException(MAX_LENGTH_EXCEEED);
+      throw new KLVException(MAX_BER_SIZE_EXCEEED);
     }
 
     byte[] octets = new byte[bersz];
@@ -173,7 +174,7 @@ public class KLVDataInput {
       val = (val << 8) + tmp;
 
       if (val < 0) {
-        throw new KLVException(MAX_LENGTH_EXCEEED);
+        throw new KLVException(MAX_BER_SIZE_EXCEEED);
       }
     }
 
@@ -202,6 +203,22 @@ public class KLVDataInput {
     readFully(value);
 
     return new MemoryTriplet(auid, value);
+  }
+
+  /**
+   * Reads the length and skips the value of a KLV triplet after its key has
+   * already been read.
+   *
+   * @throws IOException
+   * @throws EOFException
+   * @throws KLVException
+   */
+  public void skipTripletLV() throws IOException, EOFException, KLVException {
+    long len = readBERLength();
+
+    if (skipFully(len) != len) {
+      throw new EOFException();
+    }
   }
 
   public int read(byte[] b, int off, int len) throws IOException {

--- a/common/src/main/java/com/sandflow/smpte/klv/KLVDataInput.java
+++ b/common/src/main/java/com/sandflow/smpte/klv/KLVDataInput.java
@@ -172,7 +172,7 @@ public class KLVDataInput {
       int tmp = (((int) octets[i]) & 0xFF);
       val = (val << 8) + tmp;
 
-      if (val > Integer.MAX_VALUE) {
+      if (val < 0) {
         throw new KLVException(MAX_LENGTH_EXCEEED);
       }
     }

--- a/common/src/test/java/com/sandflow/smpte/klv/KLVDataInputTest.java
+++ b/common/src/test/java/com/sandflow/smpte/klv/KLVDataInputTest.java
@@ -107,12 +107,14 @@ class KLVDataInputTest {
     /* Error: value exceeds Long.MAX_VALUE */
     byte[] exceedsLong = { (byte) 0x88, (byte) 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
     KLVDataInput exceedsLongKis = new KLVDataInput(new ByteArrayInputStream(exceedsLong));
-    assertThrows(KLVException.class, exceedsLongKis::readBERLength);
+    KLVException exceedsLongException = assertThrows(KLVException.class, exceedsLongKis::readBERLength);
+    assertEquals(KLVException.MAX_BER_SIZE_EXCEEED, exceedsLongException.getMessage());
 
     /* Error: too long (> 8 bytes) */
     byte[] tooLong = { (byte) 0x89 };
     KLVDataInput kisErr = new KLVDataInput(new ByteArrayInputStream(tooLong));
-    assertThrows(KLVException.class, kisErr::readBERLength);
+    KLVException tooLongException = assertThrows(KLVException.class, kisErr::readBERLength);
+    assertEquals(KLVException.MAX_BER_SIZE_EXCEEED, tooLongException.getMessage());
 
     /* Error: EOF */
     KLVDataInput kisEOF = new KLVDataInput(new ByteArrayInputStream(new byte[0]));
@@ -147,7 +149,8 @@ class KLVDataInputTest {
     System.arraycopy(len, 0, data, key.length, len.length);
 
     KLVDataInput kis = new KLVDataInput(new ByteArrayInputStream(data));
-    assertThrows(KLVException.class, kis::readTriplet);
+    KLVException exception = assertThrows(KLVException.class, kis::readTriplet);
+    assertEquals(KLVException.MAX_LENGTH_EXCEEED, exception.getMessage());
   }
 
   @Test
@@ -181,6 +184,26 @@ class KLVDataInputTest {
 
     kis.skipFully(2);
     assertEquals(-1, kis.read());
+  }
+
+  @Test
+  void testSkipTripletLV() throws Exception {
+    byte[] shortForm = { 0x02, (byte) 0xAA, (byte) 0xBB, 0x7F };
+    KLVDataInput shortFormKis = new KLVDataInput(new ByteArrayInputStream(shortForm));
+    shortFormKis.skipTripletLV();
+    assertEquals(0x7F, shortFormKis.read());
+
+    byte[] longForm = new byte[131];
+    longForm[0] = (byte) 0x81;
+    longForm[1] = (byte) 0x80;
+    longForm[longForm.length - 1] = 0x7F;
+    KLVDataInput longFormKis = new KLVDataInput(new ByteArrayInputStream(longForm));
+    longFormKis.skipTripletLV();
+    assertEquals(0x7F, longFormKis.read());
+
+    byte[] truncated = { 0x02, (byte) 0xAA };
+    KLVDataInput truncatedKis = new KLVDataInput(new ByteArrayInputStream(truncated));
+    assertThrows(EOFException.class, truncatedKis::skipTripletLV);
   }
 
 }

--- a/common/src/test/java/com/sandflow/smpte/klv/KLVDataInputTest.java
+++ b/common/src/test/java/com/sandflow/smpte/klv/KLVDataInputTest.java
@@ -93,6 +93,22 @@ class KLVDataInputTest {
     kis = new KLVDataInput(new ByteArrayInputStream(longLen4));
     assertEquals(16777216L, kis.readBERLength());
 
+    /* Long form value larger than Integer.MAX_VALUE */
+    byte[] longLen7 = { (byte) 0x87, 0x00, 0x00, 0x01, 0x33, (byte) 0xD4, (byte) 0x8E, 0x50 };
+    kis = new KLVDataInput(new ByteArrayInputStream(longLen7));
+    assertEquals(5164535376L, kis.readBERLength());
+
+    /* Maximum supported value */
+    byte[] maxLong = { (byte) 0x88, 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+        (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF };
+    kis = new KLVDataInput(new ByteArrayInputStream(maxLong));
+    assertEquals(Long.MAX_VALUE, kis.readBERLength());
+
+    /* Error: value exceeds Long.MAX_VALUE */
+    byte[] exceedsLong = { (byte) 0x88, (byte) 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    KLVDataInput exceedsLongKis = new KLVDataInput(new ByteArrayInputStream(exceedsLong));
+    assertThrows(KLVException.class, exceedsLongKis::readBERLength);
+
     /* Error: too long (> 8 bytes) */
     byte[] tooLong = { (byte) 0x89 };
     KLVDataInput kisErr = new KLVDataInput(new ByteArrayInputStream(tooLong));
@@ -120,6 +136,18 @@ class KLVDataInputTest {
     assertArrayEquals(key, t.getKey().getBytes());
     assertEquals(2, t.getLength());
     assertArrayEquals(val, t.getValue());
+  }
+
+  @Test
+  void testReadTripletRejectsLargeValue() throws Exception {
+    byte[] key = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    byte[] len = { (byte) 0x84, (byte) 0x80, 0x00, 0x00, 0x00 };
+    byte[] data = new byte[key.length + len.length];
+    System.arraycopy(key, 0, data, 0, key.length);
+    System.arraycopy(len, 0, data, key.length, len.length);
+
+    KLVDataInput kis = new KLVDataInput(new ByteArrayInputStream(data));
+    assertThrows(KLVException.class, kis::readTriplet);
   }
 
   @Test

--- a/library/src/main/java/com/sandflow/smpte/mxf/RandomAccessFileInfo.java
+++ b/library/src/main/java/com/sandflow/smpte/mxf/RandomAccessFileInfo.java
@@ -30,7 +30,6 @@
 
 package com.sandflow.smpte.mxf;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -237,11 +236,7 @@ public class RandomAccessFileInfo {
         if (!FillItem.isInstance(key)) {
           gs.addPartition(pp.getBodyOffset(), pos);
         } else {
-          long valueLength = mis.readBERLength();
-          long skipped = mis.skipFully(valueLength);
-          if (skipped != valueLength) {
-            throw new EOFException();
-          }
+          mis.skipTripletLV();
           gs.addPartition(pp.getBodyOffset(), raip.position());
         }
 
@@ -272,11 +267,7 @@ public class RandomAccessFileInfo {
       long pos = raip.position();
       AUID key = mis.readAUID();
       if (FillItem.isInstance(key)) {
-        long valueLength = mis.readBERLength();
-        long skipped = mis.skipFully(valueLength);
-        if (skipped != valueLength) {
-          throw new EOFException();
-        }
+        mis.skipTripletLV();
         /*
          * so we have skipped a Fill Item and are either at the start of the
          * header metadata or index table

--- a/library/src/main/java/com/sandflow/smpte/mxf/RandomAccessFileInfo.java
+++ b/library/src/main/java/com/sandflow/smpte/mxf/RandomAccessFileInfo.java
@@ -30,6 +30,7 @@
 
 package com.sandflow.smpte.mxf;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,6 +44,7 @@ import com.sandflow.smpte.klv.exceptions.KLVException;
 import com.sandflow.smpte.mxf.PartitionPack.Status;
 import com.sandflow.smpte.mxf.types.IndexTableSegment;
 import com.sandflow.smpte.mxf.types.Preface;
+import com.sandflow.smpte.util.AUID;
 import com.sandflow.smpte.util.RandomAccessInputSource;
 import com.sandflow.smpte.util.UUID;
 import com.sandflow.util.events.Event;
@@ -231,11 +233,15 @@ public class RandomAccessFileInfo {
 
         /* skip over the optional fill item and map the generic stream position */
         long pos = raip.position();
-        t = mis.readTriplet();
-        FillItem fi = FillItem.fromTriplet(t);
-        if (fi == null) {
+        AUID key = mis.readAUID();
+        if (!FillItem.isInstance(key)) {
           gs.addPartition(pp.getBodyOffset(), pos);
         } else {
+          long valueLength = mis.readBERLength();
+          long skipped = mis.skipFully(valueLength);
+          if (skipped != valueLength) {
+            throw new EOFException();
+          }
           gs.addPartition(pp.getBodyOffset(), raip.position());
         }
 
@@ -264,9 +270,13 @@ public class RandomAccessFileInfo {
        * the partition pack
        */
       long pos = raip.position();
-      t = mis.readTriplet();
-      FillItem fi = FillItem.fromTriplet(t);
-      if (fi != null) {
+      AUID key = mis.readAUID();
+      if (FillItem.isInstance(key)) {
+        long valueLength = mis.readBERLength();
+        long skipped = mis.skipFully(valueLength);
+        if (skipped != valueLength) {
+          throw new EOFException();
+        }
         /*
          * so we have skipped a Fill Item and are either at the start of the
          * header metadata or index table

--- a/library/src/test/java/com/sandflow/smpte/mxf/RandomAccessReaderTest.java
+++ b/library/src/test/java/com/sandflow/smpte/mxf/RandomAccessReaderTest.java
@@ -45,6 +45,7 @@ import com.sandflow.smpte.klv.KLVDataInput;
 import com.sandflow.smpte.mxf.types.IABEssenceDescriptor;
 import com.sandflow.smpte.mxf.types.RGBADescriptor;
 import com.sandflow.smpte.util.FileRandomAccessInputSource;
+import com.sandflow.smpte.util.UL;
 
 class RandomAccessReaderTest {
 
@@ -92,6 +93,9 @@ class RandomAccessReaderTest {
     GenericStreamReader gsr = new GenericStreamReader(fi, rais);
     for (var sid : fi.getGenericStreams()) {
       gsr.seek(sid);
+      // Expected ST 410 Generic Stream Data Element key
+      assertArrayEquals(UL.fromURN("urn:smpte:ul:060e2b34.0101010c.0d010509.01000000").getBytes(),
+          gsr.getElementKey().getBytes());
       assertTrue(gsr.getElementLength() > 0);
     }
     gsr.close();


### PR DESCRIPTION
## Summary

`KLVDataInput.readBERLength()` incorrectly rejected valid definite BER lengths above `Integer.MAX_VALUE`.

The `RandomAccessFileInfo` constructor read complete KLV triplets to determine whether the KLV immediately after
the Partition Pack was an optional Fill Item.

This change allows definite BER lengths below `Long.MAX_VALUE` while preserving `readTriplet()`'s
`Integer.MAX_VALUE` in-memory allocation limit. It also updates both optional Fill Item checks in the
`RandomAccessFileInfo` constructor to inspect the KLV key first and read or skip the value only when
the key identifies a Fill Item.

Fixes #26